### PR TITLE
Add IAM policies, ACM cert, Cloudflare setup, and S3 hosting

### DIFF
--- a/cloudformation/terraform_provisioner_user.yml
+++ b/cloudformation/terraform_provisioner_user.yml
@@ -301,6 +301,40 @@ Resources:
               - cloudfront:ListCachePolicies
             Resource: '*'
 
+  SSMManagerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: This policy grants read and write permissions for System Manager parameters.
+      ManagedPolicyName: !Join
+        - '-'
+        - - !Ref ProjectName
+          - !Ref AppName
+          - ssm-parameters-rw
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowWithResource
+            Effect: Allow
+            Action:
+              # [DeleteParameter, DeleteParameters
+              - ssm:DeleteParameter*
+              - ssm:GetParameter*
+              - ssm:PutParameter
+              # [LabelParameterVersion, UnlabelParameterVersion]
+              - ssm:*ParameterVersion
+              # [AddTagsToResource, ListTagsForResource, RemoveTagsFromResource]
+              - ssm:*Tags*
+              # [DeleteResourcePolicy, GetResourcePolicies, PutResourcePolicy]
+              - ssm:*ResourcePolic*
+            Resource:
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/account-configuration/*/dev/*
+          - Sid: AllowWithoutResource
+            Effect: Allow
+            Action:
+              - ssm:DescribeParameters
+            Resource: '*'
+
+
   ProvisionerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -322,6 +356,7 @@ Resources:
         - !Ref IamPolicy
         - !Ref CertManagerPolicy
         - !Ref CloudFrontManagerPolicy
+        - !Ref SSMManagerPolicy
 
   #ProvisionerUser:
   #  Type: AWS::IAM::User

--- a/terraform/website/acm.tf
+++ b/terraform/website/acm.tf
@@ -1,0 +1,16 @@
+resource "aws_acm_certificate" "ssl" {
+  domain_name       = local.domain_name
+  validation_method = "DNS"
+
+  tags = merge(local.default_tags, {
+    Name = local.domain_name
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "ssl" {
+  certificate_arn = aws_acm_certificate.ssl.arn
+}

--- a/terraform/website/cloudflare.tf
+++ b/terraform/website/cloudflare.tf
@@ -1,0 +1,20 @@
+data "cloudflare_zone" "domain" {
+  name = var.domain_name
+}
+
+resource "cloudflare_record" "aws_acm_domain" {
+  for_each = { for opt in aws_acm_certificate.ssl.domain_validation_options : opt.domain_name => opt }
+  zone_id  = data.cloudflare_zone.domain.zone_id
+  name     = join(".", slice(split(".", each.value.resource_record_name), 0, 2))
+  content  = trimsuffix(each.value.resource_record_value, ".")
+  type     = each.value.resource_record_type
+  ttl      = 3600
+}
+
+resource "cloudflare_record" "cloudfront_distribution" {
+  zone_id = data.cloudflare_zone.domain.zone_id
+  name    = var.env == "prod" ? "" : var.env
+  content = module.cloudfront.cloudfront_distribution_domain_name
+  type    = "CNAME"
+  ttl     = 300
+}

--- a/terraform/website/cloudfront.tf
+++ b/terraform/website/cloudfront.tf
@@ -1,0 +1,65 @@
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  name = "Managed-CachingOptimized"
+}
+
+module "cloudfront" {
+  source  = "terraform-aws-modules/cloudfront/aws"
+  version = "3.4.1"
+
+  aliases             = [local.domain_name]
+  comment             = "Distribution for ${local.domain_name} website"
+  enabled             = true
+  staging             = false # If you want to create a staging distribution, set this to true
+  http_version        = "http2"
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+  retain_on_delete    = false
+  wait_for_deployment = var.aws_cloudfront_wait_for_deployment
+  default_root_object = "index.html"
+
+  create_origin_access_control = var.aws_cloudfront_create_oac
+  origin_access_control = {
+    s3_oac = {
+      description      = "CloudFront access to bucket"
+      origin_type      = "s3"
+      signing_behavior = "always"
+      signing_protocol = "sigv4"
+    }
+  }
+
+  origin = {
+    s3_oac = {
+      domain_name           = module.s3_bucket_hosting.s3_bucket_bucket_regional_domain_name
+      origin_access_control = "s3_oac" # key in `origin_access_control`
+      connection_attempts   = 3
+      connection_timeout    = 10
+      origin_shield = {
+        enabled              = true
+        origin_shield_region = var.aws_region
+      }
+    }
+  }
+
+  default_cache_behavior = {
+    target_origin_id       = "s3_oac"
+    path_pattern           = "*"
+    compress               = true
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cache_policy_id        = data.aws_cloudfront_cache_policy.caching_optimized.id
+    use_forwarded_values   = false
+  }
+
+  viewer_certificate = {
+    acm_certificate_arn            = aws_acm_certificate.ssl.arn
+    cloudfront_default_certificate = false
+    minimum_protocol_version       = "TLSv1.2_2021"
+    ssl_support_method             = "sni-only"
+  }
+
+  # custom_error_response = var.aws_cloudfront_distribution_errors_response
+
+  depends_on = [
+    aws_acm_certificate_validation.ssl
+  ]
+}

--- a/terraform/website/main.tf
+++ b/terraform/website/main.tf
@@ -1,7 +1,16 @@
-module "current_user" {
+
+locals {
+  application  = "website"
+  default_tags = merge(var.default_tags, { TerraformModule = local.application })
+
+  aws_s3_bucket_hosting = "${var.project_name}.${var.env}.com"
+  domain_name           = "${var.env}.${var.domain_name}"
+}
+
+module "current_identity" {
   source = "../modules/current-user"
 }
 
-output "current_user" {
-  value = module.current_user.details
+data "aws_ssm_parameter" "cloudflare_api_token" {
+  name = "/account-configuration/${var.aws_region}/${var.env}/cloudflare_api_token"
 }

--- a/terraform/website/outputs.tf
+++ b/terraform/website/outputs.tf
@@ -1,0 +1,33 @@
+output "workspace" {
+  description = "Nombre del workspace actual"
+  value       = var.env
+}
+
+output "project_name" {
+  description = "Nombre del proyecto"
+  value       = var.project_name
+}
+
+output "account_id" {
+  value = module.current_identity.details.account_id
+}
+
+output "caller_arn" {
+  value = module.current_identity.details.arn
+}
+
+output "s3_bucket_bucket_regional_domain_name" {
+  value = module.s3_bucket_hosting.s3_bucket_bucket_regional_domain_name
+}
+
+output "s3_bucket_website_endpoint" {
+  value = module.s3_bucket_hosting.s3_bucket_website_endpoint
+}
+
+output "aws_acm_certificate_status" {
+  value = aws_acm_certificate.ssl.status
+}
+
+output "aws_acm_certificate_validation_id" {
+  value = aws_acm_certificate_validation.ssl.id
+}

--- a/terraform/website/providers.tf
+++ b/terraform/website/providers.tf
@@ -1,0 +1,3 @@
+provider "cloudflare" {
+  api_token = data.aws_ssm_parameter.cloudflare_api_token.value
+}

--- a/terraform/website/s3.tf
+++ b/terraform/website/s3.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "allow_cloudfront_read_from_s3" {
+  policy_id = "AllowAccessToCloudFrontDistribution"
+  statement {
+    sid = "AllowCloudFrontServicePrincipal"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions = ["s3:GetObject"]
+
+    resources = ["${module.s3_bucket_hosting.s3_bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.cloudfront.cloudfront_distribution_arn]
+    }
+  }
+}
+
+module "s3_bucket_hosting" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 4.2"
+
+  bucket        = local.aws_s3_bucket_hosting
+  force_destroy = var.delete_bucket_hosting
+
+  control_object_ownership = true
+  object_ownership         = "BucketOwnerPreferred"
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.allow_cloudfront_read_from_s3.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  website = {
+    index_document = "index.html"
+  }
+
+  tags = local.default_tags
+
+  # Versioning
+  /* versioning = {
+    status = true
+  }*/
+}

--- a/terraform/website/variables.tf
+++ b/terraform/website/variables.tf
@@ -1,0 +1,54 @@
+variable "project_name" {
+  description = "Nombre del proyecto"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "Region de AWS para todos los recursos"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "env" {
+  description = "Nombre del ambiente que se está trabajando"
+  type        = string
+}
+
+variable "delete_bucket_hosting" {
+  description = "Indica si debe eliminar al bucket del hosting cuando se aplique un destroy"
+  type        = bool
+  default     = true
+}
+
+variable "domain_name" {
+  description = "Nombre del dominio para el sitio web"
+  type        = string
+}
+
+variable "aws_cloudfront_wait_for_deployment" {
+  description = "If enabled, the resource will wait for the distribution status to change from InProgress to Deployed. Setting this to false will skip the process."
+  type        = bool
+  default     = false
+}
+
+variable "aws_cloudfront_create_oac" {
+  description = "Controls if CloudFront origin access control should be created"
+  type        = bool
+  default     = true
+}
+
+variable "aws_cloudfront_distribution_errors_response" {
+  description = "Custom error responses"
+  type = list(object({
+    error_code            = number
+    response_code         = optional(number)
+    response_page_path    = optional(string)
+    error_caching_min_ttl = optional(number)
+  }))
+  default = []
+}
+
+variable "default_tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+}

--- a/terraform/website/versions.tf
+++ b/terraform/website/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "5.72.1"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "4.39.0"
+    }
+  }
+}


### PR DESCRIPTION
* IAM Policy: Added SSMManagerPolicy to grant read/write permissions for SSM parameters.
* ACM Certificate: Created a new ACM SSL certificate and validation resource for the domain.
* Cloudflare DNS: Added Cloudflare DNS records for ACM certificate validation and CloudFront distribution.
* CloudFront: Set up CloudFront distribution with SSL certificate and S3 bucket origin.
* S3 Bucket Hosting: Created an S3 bucket for website hosting with appropriate CloudFront read permissions.
* Terraform Outputs: Added outputs for workspace, project name, S3 bucket details, and ACM certificate status.
* SSM Parameter: Fetch Cloudflare API token from SSM parameter store.
* Providers: Configured Cloudflare provider to use the API token from SSM.